### PR TITLE
Revert "fix: Adding missing codec deps for iron, required for lookout and platform_perception (#38)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,15 +131,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && passwd -d ros \
     && groupmod --new-name ros ${BASE_USER}
 
-# For iron reinstall FFmpeg codec libs as they are missing
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  if [ "$ROS_DISTRO" = "iron" ]; then \
-    sudo apt-get update && \
-    sudo apt-get install --reinstall -y libmp3lame0 libxvidcore4 && \
-    sudo ldconfig; \
-  fi
-
-
 WORKDIR /home/ros
 ENV PATH="/home/ros/.local/bin:${PATH}"
 ENV ROS_OVERLAY=/opt/ros/${ROS_DISTRO}


### PR DESCRIPTION


This reverts commit eddfdc5b7debfbd5a935cf1a5cf39f9b041b5b3a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised the build process by removing unnecessary codec library dependencies, streamlining configuration and improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->